### PR TITLE
Fixing $url_path

### DIFF
--- a/basecoat/classes/routing.class.php
+++ b/basecoat/classes/routing.class.php
@@ -232,8 +232,7 @@ class Routing {
 		// Check what URL format is in use
 		if ( $this->settings['use_pretty_urls'] ) {
 			// Determine path relative to document root
-			$url_path	= str_replace(dirname($_SERVER['PHP_SELF']), '', $this->requested_url);
-			$url_path	= trim( parse_url($url_path, PHP_URL_PATH), '/');
+			$url_path	= trim( parse_url($this->requested_url, PHP_URL_PATH), '/');
 			if ( $url_path=='' ) {
 				$this->run_routes	= array('/');
 			} else {


### PR DESCRIPTION
the old line of code was looking at $_SERVER['PHP_SELF'] which only returns the /index.php file in the web directory and so dirname only returns / and thus only strips all slashes from the $this->requested_url

this change simply takes the $this->requested_url and spits out the PHP_URL_PATH
