### PR TITLE
Fixing Accidentally Removing all "/" from route

### DIFF
--- a/basecoat/classes/routing.class.php
+++ b/basecoat/classes/routing.class.php
@@ -232,8 +232,7 @@ class Routing {
 		// Check what URL format is in use
 		if ( $this->settings['use_pretty_urls'] ) {
 			// Determine path relative to document root
-			$url_path	= str_replace(dirname($_SERVER['PHP_SELF']), '', $this->requested_url);
-			$url_path	= trim( parse_url($url_path, PHP_URL_PATH), '/');
+			$url_path	= trim( parse_url($this->requested_url, PHP_URL_PATH), '/');
 			if ( $url_path=='' ) {
 				$this->run_routes	= array('/');
 			} else {


### PR DESCRIPTION
$url_path   = str_replace(dirname($_SERVER['PHP_SELF']), '', $this->requested_url);

if $_SERVER['PHP_SELF'] is "/index.php" the the dirname is "/"

if you do a string replace on "http://domain.com/some/route" with a dirname of "/" then the result is "http:domain.comsomeroute" which makes no sense.

Simply passing parse_url($this->requested_url, PHP_URL_PATH) should output the correct string of "some/route"
